### PR TITLE
Terraform template to build, upload and verify peer pod VM image

### DIFF
--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -210,7 +210,7 @@ For uploding the pod VM image using Terraform, the COS Bucket must be a regional
 
 **Note:** The `Operator` and `Console Admin` roles must be [assigned](https://cloud.ibm.com/docs/vpc?topic=vpc-vsi_is_connecting_console&interface=ui) to the user. The Terraform template will create the `Console Admin` role for the user `ibmcloud_user_id` is set to in the template `terraform.tfvars`.
 
-Execute the following commands to build, upload and verify the pod VM image.
+Execute the following commands on your client machine to build, upload and verify the pod VM image.
 
 ```
 cd ibmcloud/terraform/podvm-build

--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -174,7 +174,7 @@ COS_INSTANCE_GUID=$(ibmcloud resource service-instance --output json "$IBMCLOUD_
 ibmcloud iam authorization-policy-create is cloud-object-storage Reader --source-resource-type image --target-service-instance-id $COS_INSTANCE_GUID
 ```
 
-You can use a Terraform template located at [ibmcloud/terraform/podvm-build](./terraform/podvm-build) to use Terraform and Ansible to build a pod VM image on the k8s worker node, upload it to a COS bucket and verify it.
+You can use a Terraform template located at [ibmcloud/terraform/podvm-build](./terraform/podvm-build) to use Terraform and Ansible to build a pod VM image on the k8s worker node, upload it to a COS bucket and verify it. The architecture of the pod VM image built on the k8s worker node will be the same as that of the node. For example, a k8s worker node using an Intel x86 VSI will build an Intel x86 pod VM image and a k8s worker node using an IBM s390x VSI will build an IBM s390x pod VM image.
 
 Note that building a pod VM image on a worker node using the Terraform template is not recommended for production, and we need to build a pod VM image somewhere secure to protect workloads running in a peer pod VM.
 

--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -168,9 +168,11 @@ First, create a COS service instance if you have not create one. Then, create a 
 
 Next, you need to grant access to COS to import images as described at [https://cloud.ibm.com/docs/vpc?topic=vpc-object-storage-prereq&interface=cli](https://cloud.ibm.com/docs/vpc?topic=vpc-object-storage-prereq&interface=cli).
 
+```
 ibmcloud login -r jp-tok -apikey $api_key
 COS_INSTANCE_GUID=$(ibmcloud resource service-instance --output json "$IBMCLOUD_COS_SERVICE_INSTANCE" | jq -r '.[].guid')
 ibmcloud iam authorization-policy-create is cloud-object-storage Reader --source-resource-type image --target-service-instance-id $COS_INSTANCE_GUID
+```
 
 You can use a Terraform template located at [ibmcloud/terraform/podvm-build](./terraform/podvm-build) to use Terraform and Ansible to build a pod VM image, upload it to a COS bucket and verify it.
 

--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -204,6 +204,8 @@ The `cos_service_instance_name` and `cos_bucket_name` tfvars are optional and de
 
 For uploding the pod VM image using Terraform, the COS Bucket must be a regional bucket in the same region (default `jp-tok`) as the VPC and VSIs.
 
+**Note:** The `Operator` and `Console Admin` roles must be [assigned](https://cloud.ibm.com/docs/vpc?topic=vpc-vsi_is_connecting_console&interface=ui) to the user. The Terraform template will create the `Console Admin` role for the user `ibmcloud_user_id` is set to in the template `terraform.tfvars`.
+
 Execute the following commands to build, upload and verify the pod VM image.
 
 ```
@@ -258,9 +260,6 @@ CLOUD_PROVIDER=ibmcloud make push
 ```
 
 After successfully uploading an image, you can verify the image by creating a virtual server instance using it.
-
-**Note:** The `Operator` and `Console Admin` roles must be [assigned](https://cloud.ibm.com/docs/vpc?topic=vpc-vsi_is_connecting_console&interface=ui) to the user.
-
 
 The following command will create a new server, and delete it. The VPC and subnet name are available in the terraform configuration mentioned above. You need to change the zone name if you have changed the region.
 

--- a/ibmcloud/image/login.sh
+++ b/ibmcloud/image/login.sh
@@ -11,6 +11,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 api_key=${IBMCLOUD_API_KEY-}
 api_endpoint=${IBMCLOUD_API_ENDPOINT-https://cloud.ibm.com}
 region=${IBMCLOUD_VPC_REGION:-jp-tok}
+export IBMCLOUD_VERSION_CHECK=false
 
 ibmcloud config --http-timeout 60
 ibmcloud config --color false

--- a/ibmcloud/terraform/.gitignore
+++ b/ibmcloud/terraform/.gitignore
@@ -2,3 +2,5 @@
 terraform.tfvars
 terraform.tfstate*
 /cluster/ansible/inventory
+/podvm-build/ansible/inventory
+/podvm-build/ansible/group_vars/all

--- a/ibmcloud/terraform/cluster/variables.tf
+++ b/ibmcloud/terraform/cluster/variables.tf
@@ -1,5 +1,7 @@
 
-variable "ibmcloud_api_key" {}
+variable "ibmcloud_api_key" {
+    sensitive = true
+}
 variable "ssh_key_name" {}
 variable "cluster_name" {}
 

--- a/ibmcloud/terraform/common/variables.tf
+++ b/ibmcloud/terraform/common/variables.tf
@@ -1,5 +1,7 @@
 
-variable "ibmcloud_api_key" {}
+variable "ibmcloud_api_key" {
+    sensitive = true
+}
 
 variable "region_name" {
     default = "jp-tok"

--- a/ibmcloud/terraform/podvm-build/ansible/playbook.yml
+++ b/ibmcloud/terraform/podvm-build/ansible/playbook.yml
@@ -1,0 +1,42 @@
+#
+# (C) Copyright IBM Corp. 2022.
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+
+- hosts: all
+  remote_user: root
+  environment:
+    CLOUD_PROVIDER: ibmcloud
+  tasks:
+    - name: Set COS service endpoint for IBM Cloud
+      set_fact:
+        ibmcloud_cos_service_endpoint: https://s3.{{ ibmcloud_region_name }}.cloud-object-storage.appdomain.cloud
+      when: ibmcloud_api_endpoint == "https://cloud.ibm.com"
+    - name: Set COS service endpoint for IBM Cloud test
+      set_fact:
+        ibmcloud_cos_service_endpoint: https://s3.us-west.cloud-object-storage.test.appdomain.cloud
+      when: ibmcloud_api_endpoint == "https://test.cloud.ibm.com"
+    - name: Build peer pod VM image
+      shell:
+        cmd: |
+          . ~/.bashrc
+          make build
+        chdir: cloud-api-adaptor/ibmcloud/image
+    - name: Push peer pod VM image to Cloud Object Store and verify the image
+      environment:
+        IBMCLOUD_API_KEY: "{{ ibmcloud_api_key }}"
+        IBMCLOUD_API_ENDPOINT: "{{ ibmcloud_api_endpoint }}"
+        IBMCLOUD_COS_SERVICE_INSTANCE: "{{ ibmcloud_cos_service_instance }}"
+        IBMCLOUD_COS_BUCKET: "{{ ibmcloud_cos_bucket }}"
+        IBMCLOUD_COS_REGION: "{{ ibmcloud_region_name }}"
+        IBMCLOUD_COS_SERVICE_ENDPOINT: "{{ ibmcloud_cos_service_endpoint }}"
+        IBMCLOUD_VPC_NAME: "{{ ibmcloud_vpc_name }}"
+        IBMCLOUD_VPC_SUBNET_NAME: "{{ ibmcloud_vpc_subnet_name }}"
+        IBMCLOUD_VPC_ZONE: "{{ ibmcloud_vpc_zone }}"
+      shell:
+        cmd: |
+          . ~/.bashrc
+          make push
+          make verify
+        chdir: cloud-api-adaptor/ibmcloud/image

--- a/ibmcloud/terraform/podvm-build/ansible/playbook.yml
+++ b/ibmcloud/terraform/podvm-build/ansible/playbook.yml
@@ -33,6 +33,7 @@
         IBMCLOUD_COS_SERVICE_ENDPOINT: "{{ ibmcloud_cos_service_endpoint }}"
         IBMCLOUD_VPC_NAME: "{{ ibmcloud_vpc_name }}"
         IBMCLOUD_VPC_SUBNET_NAME: "{{ ibmcloud_vpc_subnet_name }}"
+        IBMCLOUD_VPC_REGION: "{{ ibmcloud_region_name }}"
         IBMCLOUD_VPC_ZONE: "{{ ibmcloud_vpc_zone }}"
       shell:
         cmd: |

--- a/ibmcloud/terraform/podvm-build/main.tf
+++ b/ibmcloud/terraform/podvm-build/main.tf
@@ -1,0 +1,75 @@
+#
+# (C) Copyright IBM Corp. 2022.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+locals {
+  worker_name = "${var.cluster_name}-worker"
+  worker_floating_ip_name = "${local.worker_name}-ip"
+  worker_ip = data.ibm_is_instance.worker.primary_network_interface[0].primary_ipv4_address
+  bastion_ip = data.ibm_is_floating_ip.worker.address
+  zone_name = data.ibm_is_subnet.primary.zone
+  cos_service_instance_name = var.cos_service_instance_name != null ? var.cos_service_instance_name : "${var.cluster_name}-cos-service-instance"
+  cos_bucket_name = var.cos_bucket_name != null ? var.cos_bucket_name : "${var.cluster_name}-cos-bucket"
+  ibmcloud_api_endpoint = var.use_ibmcloud_test ? "https://test.cloud.ibm.com" : "https://cloud.ibm.com"
+}
+
+data "ibm_is_instance" "worker" {
+  name = local.worker_name
+}
+
+data "ibm_is_floating_ip" "worker" {
+  name = local.worker_floating_ip_name
+}
+
+data "ibm_is_subnet" "primary" {
+  name = var.primary_subnet_name
+}
+
+resource "local_file" "inventory" {
+  filename = "./ansible/inventory"
+  content = <<EOF
+[cluster]
+${local.worker_ip}
+
+[cluster:vars]
+ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p root@${local.bastion_ip}"'
+EOF
+}
+
+resource "local_file" "group_vars" {
+  filename = "./ansible/group_vars/all"
+  content = <<EOF
+---
+
+ibmcloud_api_key: ${var.ibmcloud_api_key}
+ibmcloud_api_endpoint: ${local.ibmcloud_api_endpoint}
+ibmcloud_cos_service_instance: ${local.cos_service_instance_name}
+ibmcloud_cos_bucket: ${local.cos_bucket_name}
+ibmcloud_region_name: ${var.region_name}
+ibmcloud_vpc_name: ${var.vpc_name}
+ibmcloud_vpc_subnet_name: ${var.primary_subnet_name}
+ibmcloud_vpc_zone: ${local.zone_name}
+EOF
+}
+
+resource "ibm_iam_user_policy" "is_console_administrator_policy" {
+  ibm_id = var.ibmcloud_user_id
+  roles = ["Console Administrator"]
+
+  resources {
+    service = "is"
+  }
+}
+
+resource "null_resource" "ansible" {
+  triggers = {
+    inventory = resource.local_file.inventory.content
+    group_vars = resource.local_file.group_vars.content
+  }
+  depends_on = [ibm_iam_user_policy.is_console_administrator_policy]
+  provisioner "local-exec" {
+    working_dir = "./ansible"
+    command = "ansible-playbook -i inventory -u root ./playbook.yml"
+  }
+}

--- a/ibmcloud/terraform/podvm-build/provider.tf
+++ b/ibmcloud/terraform/podvm-build/provider.tf
@@ -1,0 +1,4 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  region = var.region_name
+}

--- a/ibmcloud/terraform/podvm-build/variables.tf
+++ b/ibmcloud/terraform/podvm-build/variables.tf
@@ -1,0 +1,31 @@
+variable "ibmcloud_api_key" {}
+variable "cluster_name" {}
+
+variable "ibmcloud_user_id" {
+  description = "User ID that owns the provided IBM Cloud API key"
+}
+
+variable "region_name" {
+    default = "jp-tok"
+}
+
+variable "vpc_name" {
+    default = "tok-vpc"
+}
+
+variable "primary_subnet_name" {
+    default = "tok-primary-subnet"
+}
+
+variable "cos_service_instance_name" {
+    default = null
+}
+
+variable "cos_bucket_name" {
+    default = null
+}
+
+variable "use_ibmcloud_test" {
+    type = bool
+    default = false
+}

--- a/ibmcloud/terraform/podvm-build/variables.tf
+++ b/ibmcloud/terraform/podvm-build/variables.tf
@@ -1,4 +1,6 @@
-variable "ibmcloud_api_key" {}
+variable "ibmcloud_api_key" {
+    sensitive = true
+}
 variable "cluster_name" {}
 
 variable "ibmcloud_user_id" {

--- a/ibmcloud/terraform/podvm-build/versions.tf
+++ b/ibmcloud/terraform/podvm-build/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = "~> 1.34.0"
+    }
+  }
+}


### PR DESCRIPTION
* Add Terraform template to build, upload and verify the podvm image
using Terraform and Ansible
* Include support for running the Terraform against test.cloud.ibm.com as well as cloud.ibm.com
* Updated documentation for running the new Terraform template
* New Terraform template tested on amd64 and s390x VSIs on IBM Cloud